### PR TITLE
New RSS 2.0 tests and fixed registerProcedure attribute for the cloud-tag.

### DIFF
--- a/src/Text/RSS/Export.hs
+++ b/src/Text/RSS/Export.hs
@@ -132,7 +132,7 @@ xmlCloud cl =
          (  mb (Attr (qualName "domain")) (rssCloudDomain cl)
 	 ++ mb (Attr (qualName "port"))   (rssCloudPort cl)
 	 ++ mb (Attr (qualName "path"))   (rssCloudPath cl)
-	 ++ mb (Attr (qualName "register")) (rssCloudRegister cl)
+	 ++ mb (Attr (qualName "registerProcedure")) (rssCloudRegisterProcedure cl)
 	 ++ mb (Attr (qualName "protocol")) (rssCloudProtocol cl)
 	 ++ rssCloudAttrs cl) }
 

--- a/src/Text/RSS/Import.hs
+++ b/src/Text/RSS/Import.hs
@@ -155,12 +155,12 @@ elementToCloud e = do
     { rssCloudDomain   = pAttr "domain" e
     , rssCloudPort     = pAttr "port" e
     , rssCloudPath     = pAttr "path" e
-    , rssCloudRegister = pAttr "register" e
+    , rssCloudRegisterProcedure = pAttr "registerProcedure" e
     , rssCloudProtocol = pAttr "protocol" e
     , rssCloudAttrs    = filter (\ a -> not (qName (attrKey a) `elem` known_attrs)) as
     }
  where
-  known_attrs = [ "domain", "port", "path", "register", "protocol" ]
+  known_attrs = [ "domain", "port", "path", "registerProcedure", "protocol" ]
 
 elementToItem :: XML.Element -> Maybe RSSItem
 elementToItem e = do

--- a/src/Text/RSS/Syntax.hs
+++ b/src/Text/RSS/Syntax.hs
@@ -131,7 +131,7 @@ data RSSCloud
      { rssCloudDomain   :: Maybe String
      , rssCloudPort     :: Maybe String -- on purpose (i.e., not an int)
      , rssCloudPath     :: Maybe String
-     , rssCloudRegister :: Maybe String
+     , rssCloudRegisterProcedure :: Maybe String
      , rssCloudProtocol :: Maybe String
      , rssCloudAttrs    :: [XML.Attr]
      }
@@ -272,7 +272,7 @@ nullCloud =
      { rssCloudDomain   = Nothing
      , rssCloudPort     = Nothing
      , rssCloudPath     = Nothing
-     , rssCloudRegister = Nothing
+     , rssCloudRegisterProcedure = Nothing
      , rssCloudProtocol = Nothing
      , rssCloudAttrs    = []
      }

--- a/tests/Text/RSS/Equals.hs
+++ b/tests/Text/RSS/Equals.hs
@@ -1,7 +1,8 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Text.RSS.Export.Equals where
+module Text.RSS.Equals where
 
 import Text.XML.Light (Element(..), Content(..), CData(..))
+import Text.RSS.Syntax (RSSCloud(..))
 
 instance Eq Element where
     (Element name1 attribs1 content1 line1) == (Element name2 attribs2 content2 line2) =
@@ -16,3 +17,13 @@ instance Eq Content where
 instance Eq CData where
     (CData verbatim1 data1 line1) == (CData verbatim2 data2 line2) =
         (verbatim1 == verbatim2) && (data1 == data2) && (line1 == line2)
+
+instance Eq RSSCloud where
+    (RSSCloud rssCloudDomain1 rssCloudPort1 rssCloudPath1 rssCloudRegisterProcedure1 rssCloudProtocol1 rssCloudAttrs1) ==
+        (RSSCloud rssCloudDomain2 rssCloudPort2 rssCloudPath2 rssCloudRegisterProcedure2 rssCloudProtocol2 rssCloudAttrs2) =
+        (rssCloudDomain1 == rssCloudDomain2)
+        && (rssCloudPort1 == rssCloudPort2)
+        && (rssCloudPath1 == rssCloudPath2)
+        && (rssCloudRegisterProcedure1 == rssCloudRegisterProcedure2)
+        && (rssCloudProtocol1 == rssCloudProtocol2)
+        && (rssCloudAttrs1 == rssCloudAttrs2)

--- a/tests/Text/RSS/Import/Tests.hs
+++ b/tests/Text/RSS/Import/Tests.hs
@@ -1,0 +1,66 @@
+module Text.RSS.Import.Tests where
+
+import Test.HUnit (Assertion, assertEqual)
+import Test.Framework (Test, mutuallyExclusive, testGroup)
+import Test.Framework.Providers.HUnit (testCase)
+import Text.RSS.Import
+import Text.RSS.Syntax
+import Text.XML.Light as XML
+import Text.RSS.Utils (createContent, createQName)
+import Text.RSS.Equals ()
+
+
+rssImportTests :: Test
+rssImportTests = testGroup "Text.RSS.Import"
+    [ mutuallyExclusive $ testGroup "RSS import"
+        [ testElementToCloudIsNotCreated
+        , testElementToCloud
+        ]
+    ]
+
+
+
+testElementToCloudIsNotCreated :: Test
+testElementToCloudIsNotCreated = testCase "should not create rss cloud" notCreateRSSCloud
+  where
+    notCreateRSSCloud :: Assertion
+    notCreateRSSCloud = do
+        let notXmlCloudElement = XML.Element { elName = createQName "notCloud", elAttribs = [], elContent = [], elLine = Nothing}
+
+        let expected = Nothing
+
+        assertEqual "not create rss cloud" expected (elementToCloud notXmlCloudElement)
+
+
+
+testElementToCloud :: Test
+testElementToCloud = testCase "should create rss cloud" createRSSCloud
+  where
+    createRSSCloud :: Assertion
+    createRSSCloud = do
+        let attr = XML.Attr { attrKey = createQName "attr" , attrVal = "text for attr" }
+
+        let xmlCloudElement = XML.Element {
+           elName = createQName "cloud"
+           , elAttribs = [
+                XML.Attr { attrKey = createQName "domain" , attrVal = "domain cloud" }
+                , XML.Attr { attrKey = createQName "port" , attrVal = "port cloud" }
+                , XML.Attr { attrKey = createQName "path" , attrVal = "path cloud" }
+                , XML.Attr { attrKey = createQName "registerProcedure" , attrVal = "register cloud" }
+                , XML.Attr { attrKey = createQName "protocol" , attrVal = "protocol cloud" }
+                , attr
+             ] :: [ Attr ]
+           , elContent = [ createContent "" ]
+           , elLine = Nothing
+        }
+
+        let expected = Just RSSCloud {
+            rssCloudDomain = Just "domain cloud"
+            , rssCloudPort = Just "port cloud"
+            , rssCloudPath = Just "path cloud"
+            , rssCloudRegisterProcedure = Just "register cloud"
+            , rssCloudProtocol = Just "protocol cloud"
+            , rssCloudAttrs = [ attr ]
+        }
+
+        assertEqual "create rss cloud" expected (elementToCloud xmlCloudElement)

--- a/tests/Text/RSS/Tests.hs
+++ b/tests/Text/RSS/Tests.hs
@@ -2,6 +2,7 @@ module Text.RSS.Tests where
 
 import Test.Framework (Test, mutuallyExclusive, testGroup)
 import Text.RSS.Export.Tests (rssExportTests)
+import Text.RSS.Import.Tests (rssImportTests)
 import Test.HUnit (Assertion, assertBool)
 import Test.Framework.Providers.HUnit (testCase)
 import Text.Feed.Export
@@ -14,7 +15,8 @@ rssTests :: Test
 rssTests = testGroup "Text.RSS"
     [ mutuallyExclusive $ testGroup "RSS"
         [ rssExportTests
-        , testFullRss20Parse
+          , rssImportTests
+          , testFullRss20Parse
         ]
     ]
 

--- a/tests/Text/RSS/Utils.hs
+++ b/tests/Text/RSS/Utils.hs
@@ -1,4 +1,4 @@
-module Text.RSS.Export.Utils where
+module Text.RSS.Utils where
 
 import Text.XML.Light as XML
 


### PR DESCRIPTION
Hi,

I have added a few more tests for RSS 2.0 and I have spotted and fixed a bug about cloud-tag.

The "cloud" tag in the code had attribute "register" instead of "registerProcedure":
https://validator.w3.org/feed/docs/rss2.html#ltcloudgtSubelementOfLtchannelgt

Thanks
Daniele