### PR TITLE
Fix toFeedDateString time format

### DIFF
--- a/src/Text/Feed/Util.hs
+++ b/src/Text/Feed/Util.hs
@@ -21,6 +21,6 @@ import System.Locale
 toFeedDateString :: FeedKind -> ClockTime -> {-Date-}String
 toFeedDateString fk ct =
   case fk of
-    AtomKind{} -> formatCalendarTime defaultTimeLocale "%Y-%m-%dT%H:%M:%sZ" (toUTCTime ct)
-    RSSKind{}  -> formatCalendarTime defaultTimeLocale "%a, %d %b %Y %H:%m:%s GMT" (toUTCTime ct)
-    RDFKind{}  -> formatCalendarTime defaultTimeLocale "%Y-%m-%dT%H:%M:%sZ" (toUTCTime ct)
+    AtomKind{} -> formatCalendarTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" (toUTCTime ct)
+    RSSKind{}  -> formatCalendarTime defaultTimeLocale "%a, %d %b %Y %H:%M:%S GMT" (toUTCTime ct)
+    RDFKind{}  -> formatCalendarTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" (toUTCTime ct)


### PR DESCRIPTION
It used `%s` (seconds since epoch) instead of `%S` (seconds of minute),
and `%m` (month) instead of `%M` (minute).

Also, a question: might it make more sense to use `UTCTime` (from the "time" package), or accept any `ParseTime` instance, instead of `ClockTime` (from "old-time") here?  Especially since `Text.Feed.Query.getItemPublishDate` uses `parseTime` from the "time" package which can't parse to a ClockTime, so you have to convert the UTCTime to a ClockTime first if you're trying to modify the field.