### PR TITLE
improve documentation with examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ HLint.hs
 cabal.sandbox.config
 dist
 setup
+.stack-work/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cabal.sandbox.config
 dist
 setup
 .stack-work/
+.ghc.environment.*

--- a/README.lhs
+++ b/README.lhs
@@ -1,0 +1,1 @@
+README.md

--- a/README.md
+++ b/README.md
@@ -1,15 +1,127 @@
-[![feed](https://budueba.com/hackage/feed)](https://hackage.haskell.org/package/feed)
+# Feed
+
+[![feed](https://img.shields.io/hackage/v/feed.svg)](http://hackage.haskell.org/package/feed)
 [![Build Status](https://travis-ci.org/bergmark/feed.svg?branch=master)](https://travis-ci.org/bergmark/feed)
 
-Interfacing with RSS (v 0.9x, 2.x, 1.0) + Atom feeds.
+## Goal
 
-To help working with the multiple feed formats we've ended up with,
-this set of modules provides parsers, pretty printers and some utility
+Interfacing with *RSS* (v 0.9x, 2.x, 1.0) + *Atom* feeds.
+
+- Parsers
+- Pretty Printers
+- Querying
+
+To help working with the multiple feed formats we've ended up with
+this set of modules providing parsers, pretty printers and some utility
 code for querying and just generally working with a concrete
 representation of feeds in Haskell.
 
-See [here](https://github.com/bergmark/feed/blob/master/tests/Example/CreateAtom.hs) for an example
-of how to create an Atom feed.
-
 For basic reading and editing of feeds, consult the documentation of
 the Text.Feed.* hierarchy.
+
+## Usage
+
+Building an Atom feed is similar to building an RSS feed, but we'll
+arbitrarily pick Atom here:
+
+We'd like to generate the XML for a minimal working example.
+Constructing our base `Feed` can use the smart constructor called `nullFeed`:
+
+*This is a pattern the library maintains for smart constructors. If you want the
+minimum viable 'X', use the 'nullX' constructor.*
+
+
+```haskell
+import qualified Text.Atom.Feed as Atom
+import qualified Text.Atom.Feed.Export as Export
+import qualified Text.XML.Light.Output as XML
+
+myFeed :: Atom.Feed
+myFeed = Atom.nullFeed
+    "http://example.com/atom.xml"       -- ^feedId
+    (Atom.TextString "Example Website") -- ^feedTitle
+    "2017-08-01"                        -- ^feedUpdated
+```
+
+```
+> XML.ppElement $ Export.xmlFeed myFeed
+"<feed xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">Example Website</title>
+  <id>http://example.com/atom.xml</id>
+  <updated>2017-8-1</updated>
+</feed>"
+```
+
+The `TextContent` sum type allows us to specify which type of text we're providing.
+
+```haskell
+data TextContent
+  = TextString String
+  | HTMLString String
+  | XHTMLString XML.Element
+  deriving (Show)
+```
+
+A feed isn't very useful without some content though, so we'll need to build up an `Entry`.
+
+```haskell
+data Post
+  = Post
+  { _postedOn :: UTCTime
+  , _url :: String
+  , _content :: String
+  }
+
+examplePosts :: [Post]
+```
+
+Our `Post` data type will need to be converted into an `Entry` in order to use it in the top level `Feed`. The required fields for an entry are a url "id" from which the entry can be presence validated, a title for the entry, and a posting date. In this example we'll also add authors, link, and the actual entries content, since we have all of this available in the `Post` provided.
+
+```haskell
+toEntry :: Post -> Atom.Entry
+toEntry (Post date url content) =
+  (Atom.nullEntry
+      url -- The ID field. Must be a link to validate.
+      (Atom.TextString (take 20 content)) -- Title
+      "2017-08-01"
+  { Atom.entryAuthors = authors
+  , Atom.entryLinks = [Atom.nullLink url]
+  , Atom.entryContent = Just (Atom.HTMLContent content)
+  }
+  where
+    authors = [
+      Atom.nullPerson { Atom.personName = "J. Smith" } ]
+```
+
+From the base feed we created earlier, we can add further details (`Link` and `Entry` content) as well as map our `toEntry` function over the posts we'd like to include in the feed.
+
+```haskell
+feed :: [Post] -> Atom.Feed
+feed posts =
+  myFeed { Atom.feedEntries = fmap toEntry posts
+         , Atom.feedLinks = [Atom.nullLink "http://example.com/"]
+         }
+```
+
+```
+> XML.ppElement $ Export.xmlFeed $ feed examplePosts
+"<feed xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">Example Website</title>
+  <id>http://example.com/atom.xml</id>
+  <updated>2017-08-01</updated>
+  <link href="http://example.com/" />
+  <entry>
+    <id>http://example.com/2</id>
+    <title type="text">Bar. Bar. Bar. Bar. </title>
+    <updated>2000-02-02T18:30:00Z</updated>
+    <author>
+      <name>J. Smith</name>
+    </author>
+    <content type="html">Bar. Bar. Bar. Bar. Bar. Bar. Bar. Bar. Bar. Bar.</content>
+    <link href="http://example.com/2" />
+  </entry>
+  ...
+</feed>"
+
+```
+See [here](https://github.com/bergmark/feed/blob/master/tests/Example/CreateAtom.hs) for this content as an uninterrupted running example.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ data Post
   }
 
 examplePosts :: [Post]
+examplePosts = []
 ```
 
 Our `Post` data type will need to be converted into an `Entry` in order to use it in the top level `Feed`. The required fields for an entry are a url "id" from which the entry can be presence validated, a title for the entry, and a posting date. In this example we'll also add authors, link, and the actual entries content, since we have all of this available in the `Post` provided.
@@ -126,3 +127,8 @@ feed posts =
 
 ```
 See [here](https://github.com/bergmark/feed/blob/master/tests/Example/CreateAtom.hs) for this content as an uninterrupted running example.
+
+```haskell
+main :: IO ()
+main = pure ()
+```

--- a/README.md
+++ b/README.md
@@ -130,5 +130,5 @@ See [here](https://github.com/bergmark/feed/blob/master/tests/Example/CreateAtom
 
 ```haskell
 main :: IO ()
-main = pure ()
+main = return ()
 ```

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ minimum viable 'X', use the 'nullX' constructor.*
 
 
 ```haskell
+import Data.Time.Clock
 import qualified Text.Atom.Feed as Atom
 import qualified Text.Atom.Feed.Export as Export
-import qualified Text.XML.Light.Output as XML
+import qualified Text.XML.Light as XML
 
 myFeed :: Atom.Feed
 myFeed = Atom.nullFeed
@@ -83,7 +84,7 @@ toEntry (Post date url content) =
   (Atom.nullEntry
       url -- The ID field. Must be a link to validate.
       (Atom.TextString (take 20 content)) -- Title
-      "2017-08-01"
+      "2017-08-01")
   { Atom.entryAuthors = authors
   , Atom.entryLinks = [Atom.nullLink url]
   , Atom.entryContent = Just (Atom.HTMLContent content)

--- a/feed.cabal
+++ b/feed.cabal
@@ -104,3 +104,14 @@ test-suite tests
     , time-locale-compat == 0.1.*
     , utf8-string < 1.1
     , xml >= 1.2.6 && < 1.4
+
+test-suite readme
+  ghc-options: -pgmL markdown-unlit
+  main-is: README.lhs
+  type: exitcode-stdio-1.0
+  build-depends:
+      base >= 4 && < 4.11
+    , feed
+    , xml >= 1.2.6 && < 1.4
+  build-tool-depends:
+      markdown-unlit:markdown-unlit == 0.4.*

--- a/feed.cabal
+++ b/feed.cabal
@@ -112,6 +112,7 @@ test-suite readme
   build-depends:
       base >= 4 && < 4.11
     , feed
+    , time < 1.9
     , xml >= 1.2.6 && < 1.4
   build-tool-depends:
       markdown-unlit:markdown-unlit == 0.4.*

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-9.0
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.0
+resolver: lts-11.1
 packages:
 - '.'
 extra-deps: []

--- a/tests/Example/CreateAtom.hs
+++ b/tests/Example/CreateAtom.hs
@@ -5,47 +5,66 @@ module Example.CreateAtom
 import Prelude ()
 import Prelude.Compat
 
+import Data.List (intercalate)
 import qualified Text.Atom.Feed as Atom
 import qualified Text.Atom.Feed.Export as Export
 import qualified Text.XML.Light.Output as XML
+import Data.Time.Format (parseTimeOrError, defaultTimeLocale, formatTime)
+import Data.Time.Clock (UTCTime)
+import Data.Maybe (fromMaybe)
 
 createAtom :: String
 createAtom = feed examplePosts
 
-examplePosts :: [(String, String, String)] -- Date, URL, Content
-examplePosts =
-  [ ("2000-02-02T18:30:00Z", "http://example.com/2", "Bar.")
-  , ("2000-01-01T18:30:00Z", "http://example.com/1", "Foo.")
-  ]
+data Post
+  = Post
+  { _postedOn :: UTCTime
+  , _url :: String
+  , _content :: String
+  }
 
-feed :: [(String, String, String)] -> String
+examplePosts :: [Post]
+examplePosts =
+  [ Post (toTimestamp "2000-02-02T18:30:00Z") "http://example.com/2" $ repeatJoin 10 "Bar."
+  , Post (toTimestamp "2000-01-01T18:30:00Z") "http://example.com/1" $ repeatJoin 10 "Foo."
+  ]
+  where
+    toTimestamp = parseTimeOrError True defaultTimeLocale "%FT%T%QZ"
+    repeatJoin n = intercalate " " . replicate n
+
+feed :: [Post] -> String
 feed posts =
   XML.ppElement . Export.xmlFeed $
-  fd
-  { Atom.feedEntries = fmap toEntry posts
-  , Atom.feedLinks = [Atom.nullLink "http://example.com/"]
+    myFeed { Atom.feedEntries = fmap toEntry posts
+           , Atom.feedLinks = [Atom.nullLink "http://example.com/"]
+           }
+  where
+    myFeed :: Atom.Feed
+    myFeed = Atom.nullFeed
+        "http://example.com/atom.xml"
+        (Atom.TextString "Example Website") -- Title
+        (fromMaybe "" maybeLatestDate)
+
+    maybeLatestDate :: Maybe String
+    maybeLatestDate = formatUTC <$> (_postedOn <$> headMaybe posts)
+
+toEntry :: Post -> Atom.Entry
+toEntry (Post date url content) =
+  (Atom.nullEntry
+      url -- The ID field. Must be a link to validate.
+      (Atom.TextString (take 20 content)) -- Title
+      (formatUTC date))
+  { Atom.entryAuthors = authors
+  , Atom.entryLinks = [Atom.nullLink url]
+  , Atom.entryContent = Just (Atom.HTMLContent content)
   }
   where
-    fd :: Atom.Feed
-    fd =
-      Atom.nullFeed
-        "http://example.com/atom.xml" -- ID
-        (Atom.TextString "Example Website") -- Title
-        (case posts -- Updated
-               of
-           (latestPostDate, _, _):_ -> latestPostDate
-           _ -> "")
-    toEntry :: (String, String, String) -> Atom.Entry
-    toEntry (date, url, content) =
-      (Atom.nullEntry
-         url -- The ID field. Must be a link to validate.
-         (Atom.TextString (take 20 content)) -- Title
-         date)
-      { Atom.entryAuthors =
-        [ Atom.nullPerson
-          { Atom.personName = "J. Smith"
-          }
-        ]
-      , Atom.entryLinks = [Atom.nullLink url]
-      , Atom.entryContent = Just (Atom.HTMLContent content)
-      }
+    authors = [
+      Atom.nullPerson { Atom.personName = "J. Smith" } ]
+
+headMaybe :: [a] -> Maybe a
+headMaybe (x:_) =Just x
+headMaybe _ = Nothing
+
+formatUTC :: UTCTime -> String
+formatUTC = formatTime defaultTimeLocale "%FT%T%QZ"

--- a/tests/Example/CreateAtom.hs
+++ b/tests/Example/CreateAtom.hs
@@ -9,8 +9,6 @@ import Data.List (intercalate)
 import qualified Text.Atom.Feed as Atom
 import qualified Text.Atom.Feed.Export as Export
 import qualified Text.XML.Light.Output as XML
-import Data.Time.Format (parseTimeOrError, defaultTimeLocale, formatTime)
-import Data.Time.Clock (UTCTime)
 import Data.Maybe (fromMaybe)
 
 createAtom :: String
@@ -18,18 +16,17 @@ createAtom = feed examplePosts
 
 data Post
   = Post
-  { _postedOn :: UTCTime
+  { _postedOn :: String
   , _url :: String
   , _content :: String
   }
 
 examplePosts :: [Post]
 examplePosts =
-  [ Post (toTimestamp "2000-02-02T18:30:00Z") "http://example.com/2" $ repeatJoin 10 "Bar."
-  , Post (toTimestamp "2000-01-01T18:30:00Z") "http://example.com/1" $ repeatJoin 10 "Foo."
+  [ Post "2000-02-02T18:30:00Z" "http://example.com/2" $ repeatJoin 10 "Bar."
+  , Post "2000-01-01T18:30:00Z" "http://example.com/1" $ repeatJoin 10 "Foo."
   ]
   where
-    toTimestamp = parseTimeOrError True defaultTimeLocale "%FT%T%QZ"
     repeatJoin n = intercalate " " . replicate n
 
 feed :: [Post] -> String
@@ -46,14 +43,14 @@ feed posts =
         (fromMaybe "" maybeLatestDate)
 
     maybeLatestDate :: Maybe String
-    maybeLatestDate = formatUTC <$> (_postedOn <$> headMaybe posts)
+    maybeLatestDate = _postedOn <$> headMaybe posts
 
 toEntry :: Post -> Atom.Entry
 toEntry (Post date url content) =
   (Atom.nullEntry
       url -- The ID field. Must be a link to validate.
       (Atom.TextString (take 20 content)) -- Title
-      (formatUTC date))
+      date)
   { Atom.entryAuthors = authors
   , Atom.entryLinks = [Atom.nullLink url]
   , Atom.entryContent = Just (Atom.HTMLContent content)
@@ -65,6 +62,3 @@ toEntry (Post date url content) =
 headMaybe :: [a] -> Maybe a
 headMaybe (x:_) =Just x
 headMaybe _ = Nothing
-
-formatUTC :: UTCTime -> String
-formatUTC = formatTime defaultTimeLocale "%FT%T%QZ"


### PR DESCRIPTION
I altered the `CreateAtom` example a bit and wrote a readme example of the steps. It would also be nice to have examples for parsing, and querying, but I've not done that here.

It's not great technical writing, but having something in the readme to give an overlook is very beneficial IMO. I'm very open to changes, additions, subtractions, etc.

Thanks for picking this library up from @sof