### PR TITLE
Changing HTMLContent to wrap an Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ toEntry (Post date url content) =
      date)
   { Atom.entryAuthors = [Atom.nullPerson {Atom.personName = "J. Smith"}]
   , Atom.entryLinks = [Atom.nullLink url]
-  , Atom.entryContent = Just (Atom.HTMLContent content)
+  , Atom.entryContent = Just (Atom.TextContent content)
   }
 ```
 

--- a/src/Text/Atom/Feed.hs
+++ b/src/Text/Atom/Feed.hs
@@ -93,7 +93,7 @@ data Entry = Entry
 
 data EntryContent
   = TextContent Text
-  | HTMLContent Text
+  | HTMLContent XML.Element
   | XHTMLContent XML.Element
   | MixedContent (Maybe Text)
                  [XML.Node]

--- a/src/Text/Atom/Feed/Export.hs
+++ b/src/Text/Atom/Feed/Export.hs
@@ -173,7 +173,7 @@ xmlContent :: EntryContent -> XML.Element
 xmlContent cont =
   case cont of
     TextContent t -> (atomLeaf "content" t) {elementAttributes = [atomAttr "type" "text"]}
-    HTMLContent t -> (atomLeaf "content" t) {elementAttributes = [atomAttr "type" "html"]}
+    HTMLContent x -> (atomNode "content" [NodeElement x]) {elementAttributes = [atomAttr "type" "html"]}
     XHTMLContent x ->
       (atomNode "content" [NodeElement x]) {elementAttributes = [atomAttr "type" "xhtml"]}
     MixedContent mbTy cs -> (atomNode "content" cs) {elementAttributes = mb (atomAttr "type") mbTy}

--- a/src/Text/Atom/Feed/Import.hs
+++ b/src/Text/Atom/Feed/Import.hs
@@ -253,7 +253,11 @@ pContent e =
   case pAttr "type" e of
     Nothing -> return (TextContent (elementTexts e))
     Just "text" -> return (TextContent (elementTexts e))
-    Just "html" -> return (HTMLContent (elementTexts e))
+    Just "html" -> 
+      case children e of
+        [] -> return (TextContent "")
+        [c] -> return (HTMLContent c)
+        _ -> Nothing
     Just "xhtml" ->
       case children e of
         [] -> return (TextContent "")

--- a/tests/Example/CreateAtom.hs
+++ b/tests/Example/CreateAtom.hs
@@ -35,7 +35,7 @@ toEntry (Post date url content) =
      date)
     { Atom.entryAuthors = [Atom.nullPerson {Atom.personName = "J. Smith"}]
     , Atom.entryLinks = [Atom.nullLink url]
-    , Atom.entryContent = Just (Atom.HTMLContent content)
+    , Atom.entryContent = Just (Atom.TextContent content)
     }
 
 feed :: [Post] -> Atom.Feed


### PR DESCRIPTION
Update HTMLContent to wrap an XML Element instead of text. Since the
HTML in a node will have been parsed as XML at this point in time, we
can treat it the same way we treat XML. This should allow users to parse
out HTML inside of a feed using their favorite XML->HTML mapping.