### PR TITLE
Get rid of xmlns:ns and ns:-prefixed attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ renderFeed = Export.textFeed
 > renderFeed myFeed
 <?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title xmlns:ns="http://www.w3.org/2005/Atom" ns:type="text">Example Website</title>
+  <title type="text">Example Website</title>
   <id>http://example.com/atom.xml</id>
   <updated>2017-08-01</updated>
 </feed>
@@ -124,29 +124,29 @@ feed =
 > renderFeed feed
 <?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title xmlns:ns="http://www.w3.org/2005/Atom" ns:type="text">Example Website</title>
+  <title type="text">Example Website</title>
   <id>http://example.com/atom.xml</id>
   <updated>2017-08-01</updated>
-  <link xmlns:ns="http://www.w3.org/2005/Atom" ns:href="http://example.com/"/>
+  <link href="http://example.com/"/>
   <entry>
     <id>http://example.com/2</id>
-    <title xmlns:ns="http://www.w3.org/2005/Atom" ns:type="text">Bar.</title>
+    <title type="text">Bar.</title>
     <updated>2000-02-02T18:30:00Z</updated>
     <author>
       <name>J. Smith</name>
     </author>
-    <content xmlns:ns="http://www.w3.org/2005/Atom" ns:type="html">Bar.</content>
-    <link xmlns:ns="http://www.w3.org/2005/Atom" ns:href="http://example.com/2"/>
+    <content type="text">Bar.</content>
+    <link href="http://example.com/2"/>
   </entry>
   <entry>
     <id>http://example.com/1</id>
-    <title xmlns:ns="http://www.w3.org/2005/Atom" ns:type="text">Foo.</title>
+    <title type="text">Foo.</title>
     <updated>2000-01-01T18:30:00Z</updated>
     <author>
       <name>J. Smith</name>
     </author>
-    <content xmlns:ns="http://www.w3.org/2005/Atom" ns:type="html">Foo.</content>
-    <link xmlns:ns="http://www.w3.org/2005/Atom" ns:href="http://example.com/1"/>
+    <content type="text">Foo.</content>
+    <link href="http://example.com/1"/>
   </entry>
 </feed>
 ```

--- a/src/Text/Atom/Feed/Export.hs
+++ b/src/Text/Atom/Feed/Export.hs
@@ -107,7 +107,7 @@ atomName :: Text -> Name
 atomName nc = Name {nameLocalName = nc, nameNamespace = Just atomNS, namePrefix = atom_prefix}
 
 atomAttr :: Text -> Text -> Attr
-atomAttr x y = (atomName x, [ContentText y])
+atomAttr x y = (Name {nameLocalName = x, nameNamespace = Nothing, namePrefix = atom_prefix}, [ContentText y])
 
 atomNode :: Text -> [Node] -> XML.Element
 atomNode x = blank_element (atomName x)


### PR DESCRIPTION
It seems that `xml-conduit` treats attributes with namespaces
differently than `xml` did and produces the following output:

```xml
<content xmlns:ns="http://www.w3.org/2005/Atom" ns:type="html">
```
instead of

```xml
<content type="html">
```

which seems to confuse some feed readers, notably
<https://github.com/lwindolf/liferea>.

If I'm interpreting https://stackoverflow.com/a/46865/3407728 correctly,
it seems that these attributes indeed aren't meant to be namespaced.
Indeed, if I inspect some `<a href="whatever">` element in a browser
using the javascript console, the element does have a namespace but the
attribute does not.

Therefore, drop the namespace from attributes.

(This is a regression introduced in f077406b845df215f. Older versions of
the library generated correct XML. Also, while fixing the examples in
README, a forgotten change of content type from 76e9f5bead56e40e8 is
applied.)