### PR TITLE
Revert "Changing HTMLContent to wrap an Elment: #35"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 1.3.0.0
+* Reverted changes to `EntryContent` that came in 1.2.0.0. Thanks to Tomas Janousek.
+
 #### 1.2.0.1
 
 * Get rid of xmlns:ns and ns:-prefixed attributes that confused some applications, thanks to Tomas Janousek.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ toEntry (Post date url content) =
      date)
   { Atom.entryAuthors = [Atom.nullPerson {Atom.personName = "J. Smith"}]
   , Atom.entryLinks = [Atom.nullLink url]
-  , Atom.entryContent = Just (Atom.TextContent content)
+  , Atom.entryContent = Just (Atom.HTMLContent content)
   }
 ```
 

--- a/feed.cabal
+++ b/feed.cabal
@@ -1,5 +1,5 @@
 name:                feed
-version:             1.2.0.1
+version:             1.3.0.0
 license:             BSD3
 license-file:        LICENSE
 category:            Text

--- a/src/Text/Atom/Feed.hs
+++ b/src/Text/Atom/Feed.hs
@@ -93,7 +93,7 @@ data Entry = Entry
 
 data EntryContent
   = TextContent Text
-  | HTMLContent XML.Element
+  | HTMLContent Text
   | XHTMLContent XML.Element
   | MixedContent (Maybe Text)
                  [XML.Node]

--- a/src/Text/Atom/Feed/Export.hs
+++ b/src/Text/Atom/Feed/Export.hs
@@ -173,7 +173,7 @@ xmlContent :: EntryContent -> XML.Element
 xmlContent cont =
   case cont of
     TextContent t -> (atomLeaf "content" t) {elementAttributes = [atomAttr "type" "text"]}
-    HTMLContent x -> (atomNode "content" [NodeElement x]) {elementAttributes = [atomAttr "type" "html"]}
+    HTMLContent t -> (atomLeaf "content" t) {elementAttributes = [atomAttr "type" "html"]}
     XHTMLContent x ->
       (atomNode "content" [NodeElement x]) {elementAttributes = [atomAttr "type" "xhtml"]}
     MixedContent mbTy cs -> (atomNode "content" cs) {elementAttributes = mb (atomAttr "type") mbTy}

--- a/src/Text/Atom/Feed/Import.hs
+++ b/src/Text/Atom/Feed/Import.hs
@@ -253,11 +253,7 @@ pContent e =
   case pAttr "type" e of
     Nothing -> return (TextContent (elementTexts e))
     Just "text" -> return (TextContent (elementTexts e))
-    Just "html" -> 
-      case children e of
-        [] -> return (TextContent "")
-        [c] -> return (HTMLContent c)
-        _ -> Nothing
+    Just "html" -> return (HTMLContent (elementTexts e))
     Just "xhtml" ->
       case children e of
         [] -> return (TextContent "")

--- a/tests/Example/CreateAtom.hs
+++ b/tests/Example/CreateAtom.hs
@@ -35,7 +35,7 @@ toEntry (Post date url content) =
      date)
     { Atom.entryAuthors = [Atom.nullPerson {Atom.personName = "J. Smith"}]
     , Atom.entryLinks = [Atom.nullLink url]
-    , Atom.entryContent = Just (Atom.TextContent content)
+    , Atom.entryContent = Just (Atom.HTMLContent content)
     }
 
 feed :: [Post] -> Atom.Feed


### PR DESCRIPTION
This reverts commit 76e9f5bead56e40e81913ceb8c17a04049e0e98d.

Based on feedback from a few users (thanks @liskin especially for bringing attention to this), it looks like I was entirely wrong here. Sorry for any pain caused! 

@bergmark Should I also bump the version number and re-release on hackage? I'm just not sure what the correct thing to do here is. 