### PR TITLE
Fix validating content

### DIFF
--- a/feed.cabal
+++ b/feed.cabal
@@ -103,6 +103,7 @@ test-suite tests
     Example.CreateAtom
     ImportExport
     Text.Atom.Tests
+    Text.Atom.Validate.Tests
     Text.Feed.Util.Tests
     Text.RSS.Equals
     Text.RSS.Export.Tests

--- a/src/Text/Atom/Feed/Import.hs
+++ b/src/Text/Atom/Feed/Import.hs
@@ -71,15 +71,17 @@ pQLeaf :: Name -> [XML.Element] -> Maybe Text
 pQLeaf x es = (T.concat . elementText) `fmap` pQNode x es
 
 pAttr :: Text -> XML.Element -> Maybe Text
-pAttr x e = (`attributeText` e) =<< fst <$> find sameAttr (elementAttributes e)
-  where
-    ax = atomName x
-    sameAttr (k, _) = k == ax || (isNothing (nameNamespace k) && nameLocalName k == x)
+pAttr x e = (`attributeText` e) =<< find (sameAtomAttr x) (map fst $ elementAttributes e)
 
 pAttrs :: Text -> XML.Element -> [Text]
 pAttrs x e = [t | ContentText t <- cnts]
   where
-    cnts = concat [v | (k, v) <- elementAttributes e, k == atomName x]
+    cnts = concat [v | (k, v) <- elementAttributes e, sameAtomAttr x k]
+
+sameAtomAttr :: Text -> Name -> Bool
+sameAtomAttr x k = k == ax || (isNothing (nameNamespace k) && nameLocalName k == x)
+  where
+    ax = atomName x
 
 pQAttr :: Name -> XML.Element -> Maybe Text
 pQAttr = attributeText

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -8,8 +8,9 @@ import Example (exampleTests)
 import ImportExport (importExportTests)
 import Test.Framework (defaultMain)
 import Text.Atom.Tests (atomTests)
+import Text.Atom.Validate.Tests (atomValidateTests)
 import Text.Feed.Util.Tests (feedUtilTests)
 import Text.RSS.Tests (rssTests)
 
 main :: IO ()
-main = defaultMain [rssTests, atomTests, feedUtilTests, exampleTests, importExportTests]
+main = defaultMain [rssTests, atomTests, atomValidateTests, feedUtilTests, exampleTests, importExportTests]

--- a/tests/Text/Atom/Validate/Tests.hs
+++ b/tests/Text/Atom/Validate/Tests.hs
@@ -1,0 +1,36 @@
+module Text.Atom.Validate.Tests
+  ( atomValidateTests
+  ) where
+
+import Prelude.Compat
+
+import Data.Text (Text)
+import Data.Text.Lazy (fromStrict)
+
+import Data.XML.Types
+
+import Test.Framework (Test, testGroup)
+import Test.Framework.Providers.HUnit (testCase)
+import Test.HUnit (Assertion, assertEqual)
+
+import Text.Atom.Feed.Validate
+
+import qualified Text.XML as C
+
+atomValidateTests :: Test
+atomValidateTests =
+  testGroup
+    "Text.Atom.Validate"
+    [testAtomValidate]
+
+sampleEntryText :: Text
+sampleEntryText = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><entry xmlns=\"http://www.w3.org/2005/Atom\"><id>http://example.com</id><title type=\"text\">example</title><updated>2000-01-01T00:00:00Z</updated><author><name>Nobody</name></author><content type=\"html\"><html xmlns=\"\"/></content></entry>"
+
+testAtomValidate :: Test
+testAtomValidate = testCase "simple entry is valid" testValid
+  where
+    testValid :: Assertion
+    testValid = do
+      let document = C.toXMLDocument $ C.parseText_ C.def $ fromStrict sampleEntryText
+      let entry = documentRoot document
+      assertEqual "" [] $ flattenT $ validateEntry entry

--- a/tests/Text/Atom/Validate/Tests.hs
+++ b/tests/Text/Atom/Validate/Tests.hs
@@ -24,7 +24,7 @@ atomValidateTests =
     [testAtomValidate]
 
 sampleEntryText :: Text
-sampleEntryText = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><entry xmlns=\"http://www.w3.org/2005/Atom\"><id>http://example.com</id><title type=\"text\">example</title><updated>2000-01-01T00:00:00Z</updated><author><name>Nobody</name></author><content type=\"html\"><html xmlns=\"\"/></content></entry>"
+sampleEntryText = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><entry xmlns=\"http://www.w3.org/2005/Atom\"><id>http://example.com</id><title type=\"text\">example</title><updated>2000-01-01T00:00:00Z</updated><author><name>Nobody</name></author><content type=\"xhtml\"><div xmlns=\"http://www.w3.org/1999/xhtml\">This is <b>XHTML</b> content.</div></content></entry>"
 
 testAtomValidate :: Test
 testAtomValidate = testCase "simple entry is valid" testValid


### PR DESCRIPTION
Fixes #44.

* Add a test to check that validation works on a simple entry.
* Change attribute handling when validating so that `type` attribute is recognised properly on `content`.