### PR TITLE
Provide renderFeedWith to allow passing xml-conduit RenderSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 Interfacing with *RSS* (v 0.9x, 2.x, 1.0) + *Atom* feeds.
 
 - Parsers
-- Pretty Printers
+- Constructors
+- Rendering
 - Querying
 
 To help working with the multiple feed formats we've ended up with
-this set of modules providing parsers, pretty printers and some utility
+this set of modules providing parsers, printers and some utility
 code for querying and just generally working with a concrete
 representation of feeds in Haskell.
 

--- a/src/Data/Text/Util.hs
+++ b/src/Data/Text/Util.hs
@@ -1,6 +1,7 @@
 module Data.Text.Util
   ( readInt
   , renderFeed
+  , renderFeedWith
   ) where
 
 import Prelude.Compat
@@ -19,10 +20,12 @@ readInt s =
     _ -> Nothing
 
 renderFeed :: (a -> XT.Element) -> a -> Maybe TL.Text
-renderFeed cf f = let e = cf f
-                      d = elToDoc e
-                  in XC.renderText XC.def <$> d
+renderFeed = renderFeedWith XC.def
 
+renderFeedWith :: XC.RenderSettings -> (a -> XT.Element) -> a -> Maybe TL.Text
+renderFeedWith opts cf f = let e = cf f
+                               d = elToDoc e
+                           in XC.renderText opts <$> d
 
 -- Ancillaries --
 

--- a/src/Text/Feed/Export.hs
+++ b/src/Text/Feed/Export.hs
@@ -14,6 +14,7 @@
 module Text.Feed.Export
   ( Text.Feed.Export.xmlFeed -- :: Feed -> XML.Element
   , Text.Feed.Export.textFeed -- :: Feed -> TL.Text
+  , Text.Feed.Export.textFeedWith
   ) where
 
 import Prelude.Compat
@@ -26,6 +27,7 @@ import Text.RSS1.Export as RSS1
 import qualified Data.Text.Util as U
 
 import Data.XML.Types as XML
+import Text.XML (RenderSettings)
 import qualified Data.Text.Lazy as TL
 
 -- | 'xmlFeed f' serializes a @Feed@ document into a conforming
@@ -40,3 +42,6 @@ xmlFeed fe =
 
 textFeed :: Feed -> Maybe TL.Text
 textFeed = U.renderFeed Text.Feed.Export.xmlFeed
+
+textFeedWith :: RenderSettings -> Feed -> Maybe TL.Text
+textFeedWith settings = U.renderFeedWith settings Text.Feed.Export.xmlFeed


### PR DESCRIPTION
It seems that as of now "provides pretty-printers" is a bit of an overstatement, given that the only way to get a `Text` out is to render it with essentially`xml-conduit`. The new helper exposes `RenderSettings` argument that can be used to actually enable pretty printing (https://hackage.haskell.org/package/xml-conduit-1.8.0.1/docs/Text-XML.html#v:rsPretty)
