### PR TITLE
Exposed feed item content through query.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,6 @@ jobs:
     - compiler: ghc-7.6.3
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-7.6.3","cabal-install-3.2"]}}
       os: linux
-    - compiler: ghc-7.4.2
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-7.4.2","cabal-install-3.2"]}}
-      os: linux
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')
   - WITHCOMPILER="-w $HC"

--- a/feed.cabal
+++ b/feed.cabal
@@ -111,7 +111,7 @@ test-suite tests
     Text.RSS.Tests
     Text.RSS.Utils
   build-depends:
-      base >= 4 && < 4.15
+      base >= 4.6 && < 4.15
     , base-compat >= 0.9 && < 0.12
     , HUnit >= 1.2 && < 1.7
     , feed
@@ -132,7 +132,7 @@ test-suite readme
     OverloadedStrings
   type:              exitcode-stdio-1.0
   build-depends:
-      base >= 4 && < 4.15
+      base >= 4.6 && < 4.15
     , base-compat >= 0.9 && < 0.12
     , text
     , xml-types

--- a/feed.cabal
+++ b/feed.cabal
@@ -24,8 +24,7 @@ bug-reports:         https://github.com/bergmark/feed/issues
 cabal-version:       >= 1.8
 build-type:          Simple
 tested-with:
-    GHC == 7.4.2
-  , GHC == 7.6.3
+    GHC == 7.6.3
   , GHC == 7.8.4
   , GHC == 7.10.3
   , GHC == 8.0.2

--- a/src/Text/RSS/Import.hs
+++ b/src/Text/RSS/Import.hs
@@ -221,6 +221,7 @@ elementToItem e = do
       , rssItemAuthor = pLeaf "author" es `mplus` pQLeaf (dcName "creator") es
       , rssItemCategories = pMany "category" elementToCategory es
       , rssItemComments = pLeaf "comments" es
+      , rssItemContent = pLeaf "content" es
       , rssItemEnclosure = pNode "enclosure" es >>= elementToEnclosure
       , rssItemGuid = pNode "guid" es >>= elementToGuid
       , rssItemPubDate = pLeaf "pubDate" es `mplus` pQLeaf (dcName "date") es

--- a/src/Text/RSS/Syntax.hs
+++ b/src/Text/RSS/Syntax.hs
@@ -91,6 +91,7 @@ data RSSItem = RSSItem
   , rssItemAuthor :: Maybe Text
   , rssItemCategories :: [RSSCategory]
   , rssItemComments :: Maybe URLString
+  , rssItemContent :: Maybe Text
   , rssItemEnclosure :: Maybe RSSEnclosure
   , rssItemGuid :: Maybe RSSGuid
   , rssItemPubDate :: Maybe DateString
@@ -200,6 +201,7 @@ nullItem title =
     , rssItemAuthor = Nothing
     , rssItemCategories = []
     , rssItemComments = Nothing
+    , rssItemContent = Nothing
     , rssItemEnclosure = Nothing
     , rssItemGuid = Nothing
     , rssItemPubDate = Nothing


### PR DESCRIPTION
I couldn't find a way to access the item contents, but looking through the code, I saw that it was indeed being parsed and accounted for, just never stored and/or exposed (depending on format).

Sorry in advance if either this already existed in some other form and I couldn't find it (in which case I'd gladly help update documentation), or was poorly implemented, still a Haskell novice. 
