### PR TITLE
Update dependencies

### DIFF
--- a/feed.cabal
+++ b/feed.cabal
@@ -77,14 +77,14 @@ library
     Data.Text.Util
     Data.XML.Compat
   build-depends:
-      base >= 4 && < 4.15
+      base >= 4 && < 4.16
     , base-compat >= 0.9 && < 0.12
-    , bytestring >= 0.9 && < 0.11
+    , bytestring >= 0.9 && < 0.12
     , old-locale == 1.0.*
     , old-time >= 1 && < 1.2
     , safe == 0.3.*
     , text < 1.3
-    , time < 1.10
+    , time < 1.12
     , time-locale-compat == 0.1.*
     , utf8-string < 1.1
     , xml-types >= 0.3.6 && < 0.4
@@ -115,7 +115,7 @@ test-suite tests
     Text.RSS.Tests
     Text.RSS.Utils
   build-depends:
-      base >= 4.6 && < 4.15
+      base >= 4.6 && < 4.16
     , base-compat >= 0.9 && < 0.12
     , HUnit >= 1.2 && < 1.7
     , feed
@@ -124,7 +124,7 @@ test-suite tests
     , test-framework == 0.8.*
     , test-framework-hunit == 0.3.*
     , text < 1.3
-    , time < 1.10
+    , time < 1.12
     , xml-types >= 0.3.6 && < 0.4
     , xml-conduit >= 1.3 && < 1.10
 
@@ -137,7 +137,7 @@ test-suite readme
     OverloadedStrings
   type:              exitcode-stdio-1.0
   build-depends:
-      base >= 4.6 && < 4.15
+      base >= 4.6
     , base-compat >= 0.9 && < 0.12
     , text
     , feed
@@ -152,7 +152,7 @@ test-suite readme-doctests
   type: exitcode-stdio-1.0
   default-language: Haskell2010
   build-depends:
-      base >= 4 && < 4.15
+      base >= 4.6
     , doctest
     , doctest-driver-gen
     , feed


### PR DESCRIPTION
Filed https://github.com/Hexirp/doctest-driver-gen/pull/14 for test-suite support for ghc 9.
